### PR TITLE
Improve README for running your own sale

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,95 +1,57 @@
-# Items for Sale
+# Home Sale Website
 
-This project contains a collection of items available for sale, organized by category. Each item is represented by a folder containing an `item_info.json` file that provides details about the item, including its category, price, and a brief description.
+This repository contains a simple static site for showcasing items for sale. Items are described with small JSON files and optional images. A Python script converts these descriptions into `data.js`, which is used by the web page.
 
-## Project Structure
+## Adding Items
 
-```
-items-for-sale
-├── items
-│   ├── Air circulator
-│   │   └── item_info.json
-│   ├── Air fryer
-│   │   └── item_info.json
-│   ├── Bar stools
-│   │   └── item_info.json
-│   ├── Bed accent pillows
-│   │   └── item_info.json
-│   ├── Bed frame
-│   │   └── item_info.json
-│   ├── Bedside lamps
-│   │   └── item_info.json
-│   ├── Bedside tables
-│   │   └── item_info.json
-│   ├── Bench
-│   │   └── item_info.json
-│   ├── Black and white rug
-│   │   └── item_info.json
-│   ├── Cane basket
-│   │   └── item_info.json
-│   ├── Chest of drawers
-│   │   └── item_info.json
-│   ├── Circle mirror
-│   │   └── item_info.json
-│   ├── Coffee machine
-│   │   └── item_info.json
-│   ├── Coffee table + side table
-│   │   └── item_info.json
-│   ├── Desk chair
-│   │   └── item_info.json
-│   ├── Fake plants
-│   │   └── item_info.json
-│   ├── Fan
-│   │   └── item_info.json
-│   ├── Food warmer
-│   │   └── item_info.json
-│   ├── Foot rest
-│   │   └── item_info.json
-│   ├── Full length mirror
-│   │   └── item_info.json
-│   ├── Kettle
-│   │   └── item_info.json
-│   ├── Knife set
-│   │   └── item_info.json
-│   ├── Laundry basket
-│   │   └── item_info.json
-│   ├── Light stand set
-│   │   └── item_info.json
-│   ├── Living room rug
-│   │   └── item_info.json
-│   ├── Mattress
-│   │   └── item_info.json
-│   ├── Nutribullet
-│   │   └── item_info.json
-│   ├── Pots and pans
-│   │   └── item_info.json
-│   ├── Rice cooker
-│   │   └── item_info.json
-│   ├── Shoe rack
-│   │   └── item_info.json
-│   ├── Standing desk
-│   │   └── item_info.json
-│   ├── Toaster
-│   │   └── item_info.json
-│   ├── TV
-│   │   └── item_info.json
-│   ├── TV console
-│   │   └── item_info.json
-│   ├── Vacuum
-│   │   └── item_info.json
-│   ├── Vanity stand
-│   │   └── item_info.json
-│   ├── Vegetable cutter
-│   │   └── item_info.json
-├── README.md
+1. Create a folder under `items/` with the item's name. Example:
+   ```
+   items/TV
+   ```
+2. Inside that folder create `item_info.json` with the following fields:
+   ```json
+   {
+     "category": "Living room",
+     "price": 100,
+     "description": "Flat screen TV, excellent condition.",
+     "sold": false
+   }
+   ```
+3. Add any number of images to the same folder. If an image filename contains `alone` it will be the default thumbnail. A file containing `context` will be shown second. All other images appear afterwards.
+
+## Generating `data.js`
+
+Run the generator after adding or editing items:
+
+```bash
+python generate_data.py
 ```
 
-## Item Details
+This scans the `items/` directory and produces `data.js` for the website.
 
-Each `item_info.json` file contains the following structure:
+## Viewing the Site
 
-- **category**: The category of the item (e.g., Living room, Entryway, Kitchen, etc.).
-- **price**: The price of the item if mentioned.
-- **description**: A brief description of the item. 
+Open `index.html` in your browser or serve the directory with a local web server. The page lets visitors sort by category or price and select items to purchase. Clicking **Buy Now** shows an alert with contact information and the cart total.
 
-Feel free to explore the items and their details!
+## Marking Items as Sold
+
+Use `python add_sold_field.py` if you need to add the `sold` flag to all items. Then manually change `"sold": true` in any `item_info.json` once an item has been purchased. The site will display a "SOLD" banner on that item.
+
+## Customizing Contact Details
+
+Edit the message inside `script.js` (near the bottom) to include your own phone number or instructions. This text appears when a buyer clicks **Buy Now**.
+
+## Example Layout
+
+```
+items/
+├── TV
+│   ├── item_info.json
+│   ├── alone.jpg
+│   └── context.jpg
+├── Sofa
+│   └── item_info.json
+└── ...
+```
+
+After running `generate_data.py`, open `index.html` to view your sale page. Feel free to adapt this project to fit your needs. Happy selling!


### PR DESCRIPTION
## Summary
- rewrite README with clearer instructions for adding items and generating the data file
- document how to view the site, mark items sold, and customize contact info

## Testing
- `git status --short`
- `git log -1 --stat`